### PR TITLE
Fix buffer overflow

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -1007,12 +1007,8 @@ impl PrimitivePolynomialField {
         if !poly.is_primitive() {
             return None;
         }
-        let mut exp_table = Vec::with_capacity(510);
-        let mut log_table = Vec::with_capacity(255);
-        unsafe {
-            exp_table.set_len(510);
-            log_table.set_len(256);
-        }
+        let mut exp_table = vec![0; 510];
+        let mut log_table = vec![0; 256];
         let mut member = 1;
         for x in 0..255 {
             exp_table[x] = member;


### PR DESCRIPTION
Found this bug by running `cargo test` with asan:
`CXXFLAGS="-fsanitize=address" CFLAGS="-fsanitize=address" RUSTFLAGS="-Zsanitizer=address" cargo test --profile=dev --target=x86_64-unknown-linux-gnu`
(requires rust nightly)

There was a vector that was too small at the moment it was initialized.
My fix is to replace the `... = Vec::with_capacity(...); unsafe { ....set_len(...) }` pattern with `vec![0, n]` directly.
This forces initialization of memory but I guess this does not really impact the preformance of `PrimitivePolynomialField::new()`.

It is still possible to keep the original pattern and replace line 1020 with `let mut log_table = Vec::with_capacity(255);`.